### PR TITLE
Revise Chat Formatting

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compileOnly("de.exlll:configlib-yaml:4.5.0")
 
     // alumina
-    implementation("games.negative.alumina:alumina:3.1.1-20250218.202811-3")
+    implementation("games.negative.alumina:alumina:3.2.1-SNAPSHOT")
 
     // bstats
     implementation("org.bstats:bstats-bukkit:3.0.2")

--- a/server/src/main/java/games/negative/spiritchat/listener/PlayerChatListener.java
+++ b/server/src/main/java/games/negative/spiritchat/listener/PlayerChatListener.java
@@ -26,6 +26,7 @@ import games.negative.spiritchat.SpiritChatPlugin;
 import games.negative.spiritchat.config.SpiritChatConfig;
 import games.negative.spiritchat.permission.Perm;
 
+import javax.imageio.stream.MemoryCacheImageInputStream;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -130,6 +131,8 @@ public class PlayerChatListener implements Listener {
                     TextComponent component = LegacyComponentSerializer.legacyAmpersand().deserialize(PlainTextComponentSerializer.plainText().serialize(message));
                     builder = builder.replace("%message%", MiniMessage.miniMessage().serialize(component));
                 } else {
+                    String input = MiniMessage.miniMessage().escapeTags(PlainTextComponentSerializer.plainText().serialize(message));
+
                     builder = builder.replace("%message%", PlainTextComponentSerializer.plainText().serialize(message));
                 }
 

--- a/server/src/main/java/games/negative/spiritchat/listener/PlayerChatListener.java
+++ b/server/src/main/java/games/negative/spiritchat/listener/PlayerChatListener.java
@@ -6,6 +6,9 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
 import games.negative.alumina.logger.Logs;
 import games.negative.alumina.message.Message;
+import games.negative.spiritchat.SpiritChatPlugin;
+import games.negative.spiritchat.config.SpiritChatConfig;
+import games.negative.spiritchat.permission.Perm;
 import io.papermc.paper.chat.ChatRenderer;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.audience.Audience;
@@ -22,11 +25,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
-import games.negative.spiritchat.SpiritChatPlugin;
-import games.negative.spiritchat.config.SpiritChatConfig;
-import games.negative.spiritchat.permission.Perm;
 
-import javax.imageio.stream.MemoryCacheImageInputStream;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -62,20 +61,7 @@ public class PlayerChatListener implements Listener {
                     .replace("%display-name%", display)
                     .replace("%username%", source.getName());
 
-            if (source.hasPermission(Perm.CHAT_COLORS)) {
-                TextComponent component = LegacyComponentSerializer.legacyAmpersand().deserialize(PlainTextComponentSerializer.plainText().serialize(message));
-                builder = builder.replace("%message%", MiniMessage.miniMessage().serialize(component));
-            } else {
-                builder = builder.replace("%message%", PlainTextComponentSerializer.plainText().serialize(message));
-            }
-
-            ItemStack item = source.getInventory().getItemInMainHand();
-            if (format().useItemDisplay() && source.hasPermission(Perm.CHAT_ITEM) && isChatItemSyntax(message) && !item.getType().isAir()) {
-                String itemMiniMessage = createItemName(item.displayName());
-
-                builder = builder.replace(Pattern.quote("{i}"), itemMiniMessage);
-                builder = builder.replace("\\{item\\}", itemMiniMessage);
-            }
+            builder = formatMessage(builder, source, message);
 
             return builder.asComponent(source);
         }
@@ -111,7 +97,7 @@ public class PlayerChatListener implements Listener {
                 });
 
         @Override
-        public Component render(@NotNull Player source, @NotNull Component display, @NotNull Component message, @NotNull Audience viewer) {
+        public @NotNull Component render(@NotNull Player source, @NotNull Component display, @NotNull Component message, @NotNull Audience viewer) {
             LuckPerms api = SpiritChatPlugin.luckperms().orElse(null);
             if (api == null) {
                 Logs.error("Could not find LuckPerms dependency on the server, yet 'use-static-format' is false!");
@@ -127,28 +113,35 @@ public class PlayerChatListener implements Listener {
                         .replace("%display-name%", display)
                         .replace("%username%", source.getName());
 
-                if (source.hasPermission(Perm.CHAT_COLORS)) {
-                    TextComponent component = LegacyComponentSerializer.legacyAmpersand().deserialize(PlainTextComponentSerializer.plainText().serialize(message));
-                    builder = builder.replace("%message%", MiniMessage.miniMessage().serialize(component));
-                } else {
-                    String input = MiniMessage.miniMessage().escapeTags(PlainTextComponentSerializer.plainText().serialize(message));
-
-                    builder = builder.replace("%message%", PlainTextComponentSerializer.plainText().serialize(message));
-                }
-
-                ItemStack item = source.getInventory().getItemInMainHand();
-                if (format().useItemDisplay() && source.hasPermission(Perm.CHAT_ITEM) && isChatItemSyntax(message) && !item.getType().isAir()) {
-                    String itemMiniMessage = createItemName(item.displayName());
-
-                    builder = builder.replace(Pattern.quote("{i}"), itemMiniMessage);
-                    builder = builder.replace("\\{item\\}", itemMiniMessage);
-                }
+                builder = formatMessage(builder, source, message);
 
                 return builder.asComponent(source);
             } catch (ExecutionException e) {
                 return new StaticGlobalChatRenderer().render(source, display, message, viewer);
             }
         }
+    }
+
+    private Message.Builder formatMessage(Message.Builder builder, Player source, Component message) {
+        if (!source.hasPermission(Perm.CHAT_COLORS)) {
+            String text = PlainTextComponentSerializer.plainText().serialize(message);
+            text = MiniMessage.miniMessage().stripTags(text);
+
+            builder = builder.replace("%message%", text);
+        } else {
+            TextComponent component = LegacyComponentSerializer.legacyAmpersand().deserialize(PlainTextComponentSerializer.plainText().serialize(message));
+            builder = builder.replace("%message%", MiniMessage.miniMessage().serialize(component));
+        }
+
+        ItemStack item = source.getInventory().getItemInMainHand();
+        if (format().useItemDisplay() && source.hasPermission(Perm.CHAT_ITEM) && isChatItemSyntax(message) && !item.getType().isAir()) {
+            String itemMiniMessage = createItemName(item.effectiveName().hoverEvent(item.asHoverEvent()));
+
+            builder = builder.replace(Pattern.quote("{i}"), itemMiniMessage);
+            builder = builder.replace("\\{item\\}", itemMiniMessage);
+        }
+
+        return builder;
     }
 
     private boolean isChatItemSyntax(@NotNull Component message) {


### PR DESCRIPTION
This pull request includes several changes to the `server` module, focusing on updating dependencies and refactoring the `PlayerChatListener` class to simplify the message formatting logic.

### Dependency Updates:
* Updated `games.negative.alumina:alumina` dependency from version `3.1.1-20250218.202811-3` to `3.2.1-SNAPSHOT` in `server/build.gradle`.

### Refactoring `PlayerChatListener`:
* Added imports for `SpiritChatPlugin`, `SpiritChatConfig`, and `Perm` in `PlayerChatListener.java`.
* Removed redundant imports for `SpiritChatPlugin`, `SpiritChatConfig`, and `Perm` in `PlayerChatListener.java`.
* Simplified message formatting by introducing a new method `formatMessage` to handle permissions and item display logic in `PlayerChatListener.java`. [[1]](diffhunk://#diff-cb55ae8d346c892b1a7d14f11e5666ec7575a402ed4b7581692ecc08d3f57126L64-R64) [[2]](diffhunk://#diff-cb55ae8d346c892b1a7d14f11e5666ec7575a402ed4b7581692ecc08d3f57126L129-R144)
* Ensured `render` method in `GroupGlobalChatRenderer` returns a non-null `Component` in `PlayerChatListener.java`.